### PR TITLE
Push large files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.step filter=lfs diff=lfs merge=lfs -text
+*.h5m filter=lfs diff=lfs merge=lfs -text

--- a/benchmarks/fng_str_heating/.gitattributes
+++ b/benchmarks/fng_str_heating/.gitattributes
@@ -1,1 +1,0 @@
-*.h5m filter=lfs diff=lfs merge=lfs -text

--- a/benchmarks/fng_str_heating/.gitattributes
+++ b/benchmarks/fng_str_heating/.gitattributes
@@ -1,0 +1,1 @@
+*.h5m filter=lfs diff=lfs merge=lfs -text

--- a/benchmarks/fng_str_heating/fng_str_heating.h5m
+++ b/benchmarks/fng_str_heating/fng_str_heating.h5m
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79d471656f1d7d00a5884d3083a663fe84f680d89a273428bc14be6b99f3b73d
+size 246823008

--- a/benchmarks/fng_str_offaxis/fng_str_offaxis.h5m
+++ b/benchmarks/fng_str_offaxis/fng_str_offaxis.h5m
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86f62d3f8d87fc2c61df7aaba30c2040afe2d114d2dc3b40b7e941ba4b919540
+size 432281316

--- a/benchmarks/fng_str_onaxis/fng_str_onaxis.h5m
+++ b/benchmarks/fng_str_onaxis/fng_str_onaxis.h5m
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4cadc39c94d1485efbf566d9ddd0cfdd941f41912af37caeab926ea5bc3c9b0
+size 246823296

--- a/benchmarks/oktavian_al/oktavian_al.h5m
+++ b/benchmarks/oktavian_al/oktavian_al.h5m
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6176c9f8e3673f30cab465765ee74eddda36e346ca16e3d75d2b19bbd958465
+size 11753952


### PR DESCRIPTION
Temporary `.h5m` files for `fng_str_onaxis`, `fng_str_offaxis`, `fng_str_heating` and `oktavian_al`.