### PR TITLE
+ oktavian_a step file

### DIFF
--- a/benchmarks/oktavian/oktavian_a.step
+++ b/benchmarks/oktavian/oktavian_a.step
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9857d176b1faa0db3247b44b198b377ddcf08e43be15e5fbc2346d2f05262966
+size 48440


### PR DESCRIPTION
This PR adds the `oktavian_a.step` file in `benchmarks/oktavian/`. It has been converted to cad with [GEOUNED](https://github.com/GEOUNED-org/GEOUNED). And it is the geometry used for `oktavian` Al, Co, Cr, Ti, W.